### PR TITLE
feat: Add support for Turso cloud database authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,8 @@ SSE_PORT=4112
 HTTP_PORT=4113
 OPENAI_API_KEY=your-openai-api-key-here
 DATABASE_URL='file:./example/database/app.db'
+# For Turso cloud database, use: libsql://your-database-name-your-username.turso.io
+DATABASE_AUTH_TOKEN=your-turso-auth-token-here
 
 # MCP interfaces control
 # Set to 'true' to enable, 'false' to disable

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -19,6 +19,7 @@ export interface ServerConfig {
 
 export interface DatabaseConfig {
   url: string;
+  authToken?: string;
 }
 
 export interface MCPConfig {
@@ -142,6 +143,7 @@ const createConfig = (): AppConfig => {
       url:
         process.env.DATABASE_URL ||
         `file:${resolve(__dirname, '../../example/database/app.db')}`,
+      authToken: process.env.DATABASE_AUTH_TOKEN,
     },
     mcp: {
       serverName: process.env.MCP_SERVER_NAME || 'SQL agent server',
@@ -235,6 +237,9 @@ export const serverConfig = {
 export const databaseConfig = {
   get url() {
     return getConfigInternal().database.url;
+  },
+  get authToken() {
+    return getConfigInternal().database.authToken;
   },
 };
 

--- a/src/database/database-manager.ts
+++ b/src/database/database-manager.ts
@@ -25,6 +25,7 @@ export class DatabaseManager {
     if (!this.client) {
       this.client = createClient({
         url: this.getDatabaseUrl(),
+        authToken: databaseConfig.authToken,
       });
     }
     return this.client;


### PR DESCRIPTION
## Summary
- Add `DATABASE_AUTH_TOKEN` environment variable support for Turso cloud database authentication
- Maintain backward compatibility with local file databases
- Update configuration interfaces and examples

## Changes
- Add `authToken` support to `DatabaseConfig` interface
- Update `database-manager.ts` to use `authToken` from configuration
- Add `databaseConfig.authToken` getter for centralized access
- Update `.env.example` with `DATABASE_AUTH_TOKEN` example and usage comments

## Usage
For local databases (current behavior):
```env
DATABASE_URL='file:./example/database/app.db'
# DATABASE_AUTH_TOKEN not needed
```

For Turso cloud databases:
```env
DATABASE_URL='libsql://your-database-name-your-username.turso.io'
DATABASE_AUTH_TOKEN=your-turso-auth-token-here
```

## Test Plan
- [x] All existing tests pass
- [x] Type checking passes  
- [x] Linting passes
- [x] Build succeeds
- [x] Backward compatibility maintained (local file databases work without authToken)
- [x] Ready for Turso cloud database integration

🤖 Generated with [Claude Code](https://claude.ai/code)